### PR TITLE
No extra params for PUT method

### DIFF
--- a/tm3_api.json
+++ b/tm3_api.json
@@ -31,7 +31,7 @@
 	    "queries": "tools/queries",
 	    "export": "tools/queries/export"
     },
-    "no-extra-param": [],
+    "no-extra-param": ["eventlocktickets"],
     "urls": {
 	  "list": {
 	    "RelationType":           "tools/queries",

--- a/tm3_api.json
+++ b/tm3_api.json
@@ -30,6 +30,7 @@
 	    "queries": "tools/queries",
 	    "export": "tools/queries/export"
     },
+    "no-extra-param": [],
     "urls": {
 	  "list": {
 	    "RelationType":           "tools/queries",

--- a/tm3_api.json
+++ b/tm3_api.json
@@ -31,7 +31,7 @@
 	    "queries": "tools/queries",
 	    "export": "tools/queries/export"
     },
-    "no-extra-param": ["eventlocktickets"],
+    "no_extra_param": ["eventlocktickets"],
     "urls": {
 	  "list": {
 	    "RelationType":           "tools/queries",

--- a/tm_api.js
+++ b/tm_api.js
@@ -47,7 +47,7 @@ function getURL(client, type, endpoint, id) {
 
 	var url_template = config.schema + "://" + config.host + config.path + config.endpoints[endpoint]
 
-	if(type == "get" || type == "put" || type == "delete") {
+	if((type == "get" || type == "put" || type == "delete") && !R.contains(endpoint,config.no_extra_param)) {
 		url_template += "/%d"
 	}
 


### PR DESCRIPTION
This change was needed since the API added `/%d` at the end of every PUT request. However, to lock tickets we need to perform a PUT request to https://apps.ticketmatic.com/api/1/{accountname}/events/{id}/tickets/lock

The request fails when the URL is formatted as: https://apps.ticketmatic.com/api/1/{accountname}/events/{id}/tickets/lock/%d

This edit allows for some endpoints to not have the `/%d` added to the end, thus allowing for put requests with id's in the payload instead of the url